### PR TITLE
Add s3 endpoint config

### DIFF
--- a/lib/pupistry/storage_aws.rb
+++ b/lib/pupistry/storage_aws.rb
@@ -42,7 +42,15 @@ module Pupistry
       end
 
       # Setup S3 bucket
-      @s3     = AWS::S3.new
+      if defined? $config['general']['s3_endpoint']
+        $logger.debug 'Connecting to alternative endpoint ' + $config['general']['s3_endpoint']
+	 @s3 = AWS::S3.new(
+	         s3_endpoint: $config['general']['s3_endpoint'],
+	         s3_force_path_style: true,
+	       )
+       else
+        @s3     = AWS::S3.new
+       end
       @bucket = @s3.buckets[$config[mode]['s3_bucket']]
     end
 

--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -10,6 +10,11 @@ general:
   # the latest version of the artifacts.
   app_cache: ~/.pupistry/cache
 
+  # If this is defined, it will talk to this endpoint instead of public
+  # AWS. You want to use this if you are using an app such as minio
+  # Set to undefined if you want to use AWS S3
+  s3_endpoint: s3.example.com
+  
   # The S3 bucket must be set in order to have a place to push and
   # pull artifact and manifests from. This bucket should be PRIVATE, we
   # only want your servers accessing the files!


### PR DESCRIPTION
Just a simple commit to add the ability to redefine the S3 endpoint to allow use of 3rd party apps that emulate S3. It seemed the simplest way to add support for other storage backends.
